### PR TITLE
Improve validation of jobs that run a SQL query

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -207,7 +207,9 @@ export async function createAPI(config: ClusterConfiguration, login: schema.Logi
             if (status.jobState === 'COMPLETED') {
               return await api.job.getResults(jobId, offset, limit)
             } else {
-              throw status.errorMessage
+              if (status.errorMessage && status.errorMessage !== '') {
+                throw status.errorMessage
+              }
             }
           } else if (timeout !== undefined) {
             if (new Date().getTime() > (start + timeout)) {


### PR DESCRIPTION
The status of a job that is not `RUNNING` is not necessarily a failed job. [According to the API reference](https://docs.dremio.com/rest-api/jobs/get-job.html#jobstatus-response-output) a job can have a status that is not `FAILED` (or `CANCELLED`) that do not throw an error message. The current validation of the status of the job only checks if the job is not in `RUNNING` nor it is a `COMPLETED` job and throws and error if so, but if for some reason the job is in `PENDING` or any other status that doesn't represent a failed job it will throw an error with an empty message.